### PR TITLE
Refatora Script de seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.swp

--- a/database.js
+++ b/database.js
@@ -1,0 +1,15 @@
+const Sequelize = require('sequelize')
+const {DATABASE_URL} = require('./settings.js')
+
+module.exports = {
+  connect() {
+    return new Sequelize(DATABASE_URL, {
+      dialect: 'postgres',
+      define: {
+        underscored: true,
+        timestamps: false,
+      }
+    })
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "db:start": "docker run --rm --name prescare-database -p 5432:5432 -e POSTGRES_PASSWORD=prescare -d postgres",
     "db:create": "docker exec -it prescare-database psql -U postgres -c 'CREATE DATABASE prescare' ",
     "db:console": "docker exec -it prescare-database psql -U postgres -d prescare",
-    "db:reset": "npm run db:stop; sleep 1; npm run db:remove; sleep 2; npm run db:start; sleep 2; npm run db:create",
-    "db:stop": "docker stop prescare-database"
+    "db:reset": "npm run db:stop; sleep 1; npm run db:start; sleep 2; npm run db:create",
+    "db:stop": "docker stop prescare-database",
+    "db:seed": "npm run db:reset && node seed.js"
   },
   "repository": {
     "type": "git",

--- a/seed.js
+++ b/seed.js
@@ -1,65 +1,56 @@
-const Sequelize = require('sequelize')
-const settings = require('./settings')
+const database = require('./database')
+const modelsInitializer = require('./src/models')
 
-const databaseConnection = new Sequelize(settings.DATABASE_URL, {
-  dialect: "postgres",
-  define: {
-    underscored: true,
-    timestamps: false
-  }
+const databaseConnection = database.connect()
+
+const models = modelsInitializer(databaseConnection)
+
+const createAcolhido = () => models.Acolhido.create({
+  nome: 'Josicleiso Dores',
+  idade: 12,
+  rg: '123456',
+  peso: 12.5,
+  alergias: 'Paracetamol',
+  viaAlimentacao: 'Oral'
 })
 
-const models = require('./src/models')(databaseConnection)
+const createPrescricao = (acolhido) => models.Prescricao.create({
+  data: Date.now(),
+  validade: Date.now(),
+  acolhido_id: acolhido.id
+})
 
-const seedDatabase = models => () => {
-  models.Acolhido.findOrCreate({
-    where: { nome: "Josicleiso Dores" },
-    defaults: {
-      nome: "Josicleiso Dores",
-      idade: 12,
-      rg: "123456",
-      peso: 12.5,
-      alergias: "Paracetamol",
-      viaAlimentacao: "Oral"
-    }
-  }).spread((acolhido, created) => {
-    if (!created) {
-      return;
-    }
+const createMedicamento = (prescricao) => models.Medicamento.create({
+  nome: 'Dorflex',
+  intervalo: '8h-8h',
+  via: 'Oral',
+  formaFarmaceutica: 'Paracetamol',
+  dosagem: '1cp',
+  validade: '2018',
+  lote: '213213iu1griusadoas',
+  prescricao_id: prescricao.id
+})
+.then(() => prescricao)
 
-    models.Prescricao.create({
-      data: Date.now(),
-      validade: Date.now(),
-      acolhido_id: acolhido.id
-    }).then(prescricao => {
-      models.Medicamento.create({
-        nome: "Dorflex",
-        intervalo: "8h-8h",
-        via: "Oral",
-        formaFarmaceutica: "Paracetamol",
-        dosagem: "1cp",
-        validade: "2018",
-        lote: "213213iu1griusadoas",
-        prescricao_id: prescricao.id
-      }).then(() => {
-        models.Cuidado.create({
-          descricao: "Dar banho",
-          intervalo: "12h-12h",
-          observacoes: "Com Jhonsons Baby",
-          prescricao_id: prescricao.id
-        }).then(() => {
-          models.Dieta.create({
-            tipo: "Hipercalórica",
-            intervalo: "12h-12h",
-            prescricao_id: prescricao.id
-          });
-        });
-      });
-    });
-  });
+const createCuidado = (prescricao) => models.Cuidado.create({
+  descricao: 'Dar banho',
+  intervalo: '12h-12h',
+  observacoes: 'Com Jhonsons Baby',
+  prescricao_id: prescricao.id
+})
+
+const letItCrash = (error) => {
+  console.trace('Erro durante o seed:', error.message)
+  process.exit(1)
 }
+
+const finishWithSuccess = () => process.exit(0)
 
 databaseConnection
   .sync()
-  .then(seedDatabase(models))
-  .then(process.exit)
+  .then(createAcolhido)
+  .then(createPrescricao)
+  .then(createMedicamento)
+  .then(createCuidado)
+  .then(finishWithSuccess)
+  .catch(letItCrash)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,10 +9,11 @@ const prescricaoRoutes = require('./prescricao')
 
 module.exports = models => {
   applicationRoutes(router),
-    acolhidoRoutes(models.Acolhido, router),
-    prescricaoRoutes(models.Prescricao, models.Dieta, models.Acolhido, router),
-    dietaRoutes(models.Dieta, router),
-    cuidadoRoutes(models.Cuidado, router),
-    medicamentoRoutes(models.Medicamento, router)
+  acolhidoRoutes(models.Acolhido, router),
+  prescricaoRoutes(models.Prescricao, models.Dieta, models.Acolhido, router),
+  dietaRoutes(models.Dieta, router),
+  cuidadoRoutes(models.Cuidado, router),
+  medicamentoRoutes(models.Medicamento, router)
+
   return router;
 }


### PR DESCRIPTION
Esta PR refatora os scripts de seeding do banco de dados. A premissa é a de que o seeding somente é executado nos ambientes de desenvolvimento e talvez staging/teste. Partindo desta premissa, o script irá apagar o banco, recriando os registros mínimos.

Algumas das alterações mais relevantes:

__database.js__ 

Este módulo unifica a maneira de se conectar no banco de dados, ou seja, tanto `seed.js` quanto `app.js` usam as mesmas configurações do Sequelize na hora de se conectar. Isso evita divergência de configuração entre os módulos, o que pode gerar vários problemas.

Exemplo: `app.js` configura a conexão para criar tabelas com nomes separados por underline (`medicamentos_acolhido`, por exemplo) enquanto `seed.js` usa `camelCase`, causando o caos.

__process.exit(0)__ e __process.exit(1)__

O Sequelize não desfaz a conexão com o banco de dados quando algo dá certo ou errado, o que mantém a aplicação/script pendurados. Para isso, usamos `process.exit`. Por convenção dos sistemas operacionais, `0` significa que o programa executou de maneira bem sucedida e `1` indica o contrário. Existe uma lista de códigos para saída de um programa. Cada código indica um motivo de o programa ter parado. Para mais detalhes, vejam [este link](http://tldp.org/LDP/abs/html/exitcodes.html).