### PR TITLE
00: passport como dependência de produção

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,5 +1,5 @@
 fileignoreconfig:
-- filename: docker-compose.yml
-  checksum: f8ae8b42b8cb3037f97b9f9ae4272a090c7be00c848e13d985bca128619966c7
+- filename: package-lock.json
+  checksum: 25edf73f6eac9ef1aaa7c93ba2b57fe955c449a29ea0af8da2df0a07d1d54de1
   ignore_detectors: []
 scopeconfig: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -666,11 +666,6 @@
         }
       }
     },
-    "bcrypt-nodejs": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
-      "integrity": "sha1-xgkX8m3CNWYVZsaBBhwwPCsohCs="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2639,7 +2634,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2660,12 +2656,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2680,17 +2678,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2807,7 +2808,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2819,6 +2821,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2833,6 +2836,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2840,12 +2844,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2864,6 +2870,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2951,7 +2958,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2963,6 +2971,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3048,7 +3057,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3084,6 +3094,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3103,6 +3114,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3146,12 +3158,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9270,7 +9284,7 @@
         },
         "registry-auth-token": {
           "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+          "resolved": false,
           "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
           "dev": true,
           "requires": {
@@ -9916,7 +9930,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
       "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
-      "dev": true,
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
@@ -10053,8 +10066,7 @@
     "pause": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
-      "dev": true
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pause-stream": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "method-override": "~2.3.6",
     "moment": "^2.22.2",
     "morgan": "^1.9.1",
+    "passport": "^0.4.0",
     "passport-facebook": "~2.1.1",
     "passport-google-oauth": "~1.0.0",
     "passport-local": "~1.0.0",
@@ -55,7 +56,6 @@
     "eslint-plugin-jest": "^21.17.0",
     "jest": "^23.0.1",
     "nodemon": "^1.17.4",
-    "npx": "^10.2.0",
-    "passport": "^0.4.0"
+    "npx": "^10.2.0"
   }
 }


### PR DESCRIPTION
O passport eh uma dependencia de producao que estava declarada nos
devDependencies. Por padrao, o npm fara um install somente de
dependencias de producao (o que faz todo sentido), o que quebrara o
deploy:

<img width="1915" alt="Screen Shot 2019-11-15 at 23 26 10" src="https://user-images.githubusercontent.com/4705127/68986660-3c206680-0800-11ea-9a89-9447781eb2c4.png">
